### PR TITLE
Add `WithNoEscape(bool)` function to disable HTML escaping globally

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "mustache"]
 	path = mustache
-	url = git://github.com/mustache/spec.git
+	url = https://github.com/mustache/spec

--- a/README.md
+++ b/README.md
@@ -1289,7 +1289,6 @@ These handlebars options are currently NOT implemented:
 - `knownHelpers` - list of helpers that are known to exist (truthy) at template execution time
 - `knownHelpersOnly` - allows further optimizations based on the known helpers list
 - `trackIds` - include the id names used to resolve parameters for helpers
-- `noEscape` - disables HTML escaping globally
 - `strict` - templates will throw rather than silently ignore missing fields
 - `assumeObjects` - removes object existence checks when traversing paths
 - `preventIndent` - disables the auto-indententation of nested partials

--- a/eval.go
+++ b/eval.go
@@ -42,6 +42,9 @@ type evalVisitor struct {
 
 	// used for info on panic
 	curNode ast.Node
+
+	// do not escape
+	noEscape bool
 }
 
 // NewEvalVisitor instanciate a new evaluation visitor with given context and initial private data frame
@@ -806,7 +809,7 @@ func (v *evalVisitor) VisitMustache(node *ast.MustacheStatement) interface{} {
 
 	// get string value
 	str := Str(expr)
-	if !isSafe && !node.Unescaped {
+	if !v.noEscape && !isSafe && !node.Unescaped {
 		// escape html
 		str = Escape(str)
 	}

--- a/eval_test.go
+++ b/eval_test.go
@@ -295,3 +295,19 @@ func TestEvalMethodReturningFunc(t *testing.T) {
 		t.Errorf("Failed to evaluate struct method: %s", output)
 	}
 }
+
+func TestEvalNoEscape(t *testing.T) {
+	t.Parallel()
+
+	source := `Hello {{value}}`
+	expected := `Hello <strong>World</strong>`
+
+	ctx := map[string]string{
+		"value": "<strong>World</strong>",
+	}
+
+	output := MustRender(source, ctx, WithNoEscape(true))
+	if output != expected {
+		t.Errorf("Failed to evaluate struct method: %s", output)
+	}
+}

--- a/handlebars.go
+++ b/handlebars.go
@@ -4,7 +4,7 @@ package handlebars
 // Render parses a template and evaluates it with given context
 //
 // Note that this function call is not optimal as your template is parsed everytime you call it. You should use Parse() function instead.
-func Render(source string, ctx interface{}) (string, error) {
+func Render(source string, ctx interface{}, opts ...execOption) (string, error) {
 	// parse template
 	tpl, err := Parse(source)
 	if err != nil {
@@ -12,7 +12,7 @@ func Render(source string, ctx interface{}) (string, error) {
 	}
 
 	// renders template
-	str, err := tpl.Exec(ctx)
+	str, err := tpl.Exec(ctx, opts...)
 	if err != nil {
 		return "", err
 	}
@@ -23,6 +23,6 @@ func Render(source string, ctx interface{}) (string, error) {
 // MustRender parses a template and evaluates it with given context. It panics on error.
 //
 // Note that this function call is not optimal as your template is parsed everytime you call it. You should use Parse() function instead.
-func MustRender(source string, ctx interface{}) string {
-	return MustParse(source).MustExec(ctx)
+func MustRender(source string, ctx interface{}, opts ...execOption) string {
+	return MustParse(source).MustExec(ctx, opts...)
 }


### PR DESCRIPTION
[Handlebars support `noEscape` option](https://handlebarsjs.com/api-reference/compilation.html#handlebars-compile-template-options) and this PR add such feature with functional options pattern.

Now users can use `WithNoEscape()` like

```go
source := `<div class="entry">
  <h1>{{title}}</h1>
  <div class="body">
    {{body}}
  </div>
</div>
`

ctx := map[string]string{
    "title": "All about <p> Tags",
    "body":  "<p>This is a post about &lt;p&gt; tags</p>",
}

tpl := handlebars.MustParse(source, handlebars.WithNoEscape(true))
result := tpl.MustExec(ctx)

fmt.Print(result)
```

I'm not sure if my changes are enough for `noEscape` option so let me know additional changes are required